### PR TITLE
Add FreeBSD install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ cargo install sd
 
 [AUR package for sd](https://aur.archlinux.org/packages/sd/).
 
+
+### FreeBSD
+
+```sh
+pkg install sd
+```
+
 ## Quick Guide
 
 1. **String-literal mode**. By default, expressions are treated as regex. Use `-s` or `--string-mode` to disable regex.


### PR DESCRIPTION
I've created a FreeBSD port for sd [1]. It'll soon be available in the official package repository.

[1] https://www.freshports.org/textproc/sd