### PR TITLE
Optimize release size.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ regex-syntax = "0.6.5"
 unescape = "0.1.0"
 
 [profile.release]
-opt-level = 3
+codegen-units = 1
 lto = true
-debug = false
+opt-level = 'z'
+panic = 'abort'


### PR DESCRIPTION
Based on https://github.com/johnthagen/min-sized-rust.

## Before
```shell
cargo build --release
du target/release/sd
2.0M    target/release/sd
```

## After
```shell
cargo build --release
du target/release/sd
1.7M    target/release/sd
```

➡️ Another good optimization would be to strip the symbols from the binary:
```shell
strip target/release/sd 
du target/release/sd   
1.1M    target/release/sd
```