### PR TITLE
Convert str to bytes to call replacer.replace

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -178,7 +178,10 @@ mod tests {
             flags.map(ToOwned::to_owned),
         )
         .unwrap();
-        assert_eq!(std::str::from_utf8(&replacer.replace(src)), Ok(target));
+        assert_eq!(
+            std::str::from_utf8(&replacer.replace(src.as_bytes())),
+            Ok(target)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fix #39

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Build tested on Fedora Rawhide.