### PR TITLE
Adding aarch64-apple-darwin target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,10 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Adding `aarch64-apple-darwin` target in tests and builds.