### PR TITLE
Fix master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            use-cross: true
 
     steps:
     - name: Checkout repository
@@ -46,6 +46,16 @@ jobs:
         profile: minimal
         override: true
         target: ${{ matrix.target }}
+
+    - name: Create .cargo/config.toml
+      if: ${{ matrix.use-cross == true }}
+      shell: bash
+      run: |
+           mkdir .cargo
+           cat > .cargo/config.toml <<EOF
+           [target.${{ matrix.target }}]
+           rustflags = ["--cfg", "sd_cross_compile"]
+           EOF
 
     - name: Test
       uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,6 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            use-cross: true
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
In #115 I have observed that the builds for the targets `arm-unknown-linux-gnueabihf` and `aarch64-apple-darwin` are not running, even on the current master branch. Reasons for their failures can be found in the commit descriptions.