### PR TITLE
Fix tests

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -78,7 +78,6 @@ impl App {
                     let file =
                         unsafe { memmap::Mmap::map(&File::open(path)?)? };
                     if self.replacer.has_matches(&file) {
-                        println!("{}", path.display());
                         handle
                             .write_all(&self.replacer.replace_preview(&file))?;
                     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -46,11 +46,14 @@ mod cli {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write(b"abc123def")?;
 
-        #[rustfmt::skip]
-    sd().args(&["-p", "abc\\d+", "", file.path().to_str().unwrap()])
-        .assert()
-        .success()
-        .stdout("def");
+        sd().args(&["-p", "abc\\d+", "", file.path().to_str().unwrap()])
+            .assert()
+            .success()
+            .stdout(format!(
+                "{}{}def",
+                ansi_term::Color::Green.prefix().to_string(),
+                ansi_term::Color::Green.suffix().to_string()
+            ));
 
         assert_file(file.path(), "abc123def");
 


### PR DESCRIPTION
The commit https://github.com/chmln/sd/commit/29dd367971218e3c20ed7886232ae352f63d5d65 broke the tests. This fixes it. The path of the file is no longer printed out in the preview, since in my opinion that can be confusing.