### PR TITLE
Fix recursive preview (show file path)

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -69,6 +69,7 @@ impl App {
             (Source::Files(paths), true) => {
                 let stdout = std::io::stdout();
                 let mut handle = stdout.lock();
+                let print_path = paths.len() > 1;
 
                 paths.iter().try_for_each(|path| {
                     if let Err(_) = Replacer::check_not_empty(File::open(path)?)
@@ -78,8 +79,17 @@ impl App {
                     let file =
                         unsafe { memmap::Mmap::map(&File::open(path)?)? };
                     if self.replacer.has_matches(&file) {
+                        if print_path {
+                            writeln!(
+                                handle,
+                                "----- FILE {} -----",
+                                path.display()
+                            )?;
+                        }
+
                         handle
                             .write_all(&self.replacer.replace_preview(&file))?;
+                        writeln!(handle)?;
                     }
 
                     Ok(())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -82,7 +82,7 @@ mod cli {
             .assert()
             .success()
             .stdout(format!(
-                "{}{}def",
+                "{}{}def\n",
                 ansi_term::Color::Green.prefix().to_string(),
                 ansi_term::Color::Green.suffix().to_string()
             ));


### PR DESCRIPTION
Unfortunately, I introduced with my last commit https://github.com/chmln/sd/commit/7d73f9f2baf0a60d9bd15187b6088ae87c914eb7 some unwanted behaviour (sorry). If you wanted to see the preview for multiple files (e. g. recursive mode), it only printed the contents and you could not differentiate between the files.

With this commit, the file path is printed when you use the preview for more than one file. Also, a new line is now printed at the end of the file contents (only for the preview), so that something like this won’t happen: `content_of_file_before----- FILE ./some_path.txt -----`

Some examples of the current behaviour:
Contents of the files e.txt and f.txt are both:
```
ffffff
```

```
$ sd -p  "f" "a" f.txt 
aaaaaa
$
```

```
$ sd -p  "f" "a" e.txt f.txt 
----- FILE e.txt -----
aaaaaa
----- FILE f.txt -----
aaaaaa
$
```