### PR TITLE
Build Adjustments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,11 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            use-cross: true
+
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            use-cross: true
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: true
+            use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,6 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             use-cross: true
 
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            use-cross: false
-
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,11 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             use-cross: true
 
+          # This isn't working right now. See this: https://github.com/chmln/sd/pull/179#discussion_r1195840367
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   use-cross: false
+
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,10 +66,6 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release --locked
 
-    - name: Strip binary
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      run: strip target/${{ matrix.target }}/release/sd
-
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v1-release
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: true
+            use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             use-cross: true
 
+          # This isn't working right now. See this: https://github.com/chmln/sd/pull/179#discussion_r1195840870
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   use-cross: false
+
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,6 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             use-cross: true
 
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            use-cross: false
-
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,14 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: true
+
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            use-cross: true
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,10 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            use-cross: false
+          # This isn't working right now. See this: https://github.com/chmln/sd/pull/179#discussion_r1195840870
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
+          #   use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ man = "0.3.0"
 [profile.release]
 opt-level = 3
 lto = true
+strip = true


### PR DESCRIPTION
Adjustments to build targets to include an AWS Graviton target and strip binaries during cargo build, instead of doing so manually after the fact.

Unfortunately, for this to work, I had to abandon Windows builds, as I'm not familiar enough with Windows to figure out how to make that work.