### PR TITLE
Add editor config file matching rustfmt config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.rs]
+max_line_length = 80


### PR DESCRIPTION
This just adds an `.editorconfig` file with the line limit matching the custom line limit set in the `.rustfmt.toml`