### PR TITLE
Fix warnings and clippy lints

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use structopt::{clap::AppSettings, StructOpt};
     setting(AppSettings::NextLineHelp),
     setting(AppSettings::UnifiedHelpMessage)
 )]
-pub(crate) struct Options {
+pub struct Options {
     #[structopt(short = "p", long = "preview")]
     /// Output result into stdout and do not modify files.
     pub preview: bool,

--- a/src/input.rs
+++ b/src/input.rs
@@ -72,8 +72,7 @@ impl App {
                 let print_path = paths.len() > 1;
 
                 paths.iter().try_for_each(|path| {
-                    if let Err(_) = Replacer::check_not_empty(File::open(path)?)
-                    {
+                    if Replacer::check_not_empty(File::open(path)?).is_err() {
                         return Ok(());
                     }
                     let file =

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
 
     let source = if options.recursive {
         Source::recursive()?
-    } else if options.files.len() > 0 {
+    } else if options.files.is_empty() {
         Source::Files(options.files)
     } else {
         Source::Stdin

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
 
     let source = if options.recursive {
         Source::recursive()?
-    } else if options.files.is_empty() {
+    } else if !options.files.is_empty() {
         Source::Files(options.files)
     } else {
         Source::Stdin

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -103,7 +103,7 @@ impl Replacer {
         self.regex.split(content).for_each(|sur_text| {
             use regex::bytes::Replacer;
 
-            &v.extend(sur_text);
+            v.extend(sur_text);
             if let Some(capture) = captures.next() {
                 v.extend_from_slice(
                     ansi_term::Color::Green.prefix().to_string().as_bytes(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -28,13 +28,13 @@ mod cli {
     #[test]
     fn in_place() -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
-        file.write(b"abc123def")?;
+        file.write_all(b"abc123def")?;
         let path = file.into_temp_path();
 
-        sd().args(&["abc\\d+", "", path.to_str().unwrap()])
+        sd().args(["abc\\d+", "", path.to_str().unwrap()])
             .assert()
             .success();
-        assert_file(&path.to_path_buf(), "def");
+        assert_file(&path, "def");
 
         Ok(())
     }
@@ -42,13 +42,13 @@ mod cli {
     #[test]
     fn in_place_with_empty_result_file() -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
-        file.write(b"a7c")?;
+        file.write_all(b"a7c")?;
         let path = file.into_temp_path();
 
-        sd().args(&["a\\dc", "", path.to_str().unwrap()])
+        sd().args(["a\\dc", "", path.to_str().unwrap()])
             .assert()
             .success();
-        assert_file(&path.to_path_buf(), "");
+        assert_file(&path, "");
 
         Ok(())
     }
@@ -63,11 +63,11 @@ mod cli {
         create_soft_link(&file, &link)?;
         std::fs::write(&file, "abc123def")?;
 
-        sd().args(&["abc\\d+", "", link.to_str().unwrap()])
+        sd().args(["abc\\d+", "", link.to_str().unwrap()])
             .assert()
             .success();
 
-        assert_file(&file.to_path_buf(), "def");
+        assert_file(&file, "def");
         assert!(std::fs::symlink_metadata(link)?.file_type().is_symlink());
 
         Ok(())
@@ -76,15 +76,15 @@ mod cli {
     #[test]
     fn replace_into_stdout() -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
-        file.write(b"abc123def")?;
+        file.write_all(b"abc123def")?;
 
-        sd().args(&["-p", "abc\\d+", "", file.path().to_str().unwrap()])
+        sd().args(["-p", "abc\\d+", "", file.path().to_str().unwrap()])
             .assert()
             .success()
             .stdout(format!(
                 "{}{}def\n",
-                ansi_term::Color::Green.prefix().to_string(),
-                ansi_term::Color::Green.suffix().to_string()
+                ansi_term::Color::Green.prefix(),
+                ansi_term::Color::Green.suffix()
             ));
 
         assert_file(file.path(), "abc123def");
@@ -94,7 +94,7 @@ mod cli {
 
     #[test]
     fn stdin() -> Result<()> {
-        sd().args(&["abc\\d+", ""])
+        sd().args(["abc\\d+", ""])
             .write_stdin("abc123def")
             .assert()
             .success()


### PR DESCRIPTION
This fixes both `cargo check` warnings and `clippy` lints