### PR TITLE
Switch `atty` for `is-terminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,9 +573,9 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "assert_cmd",
- "atty",
  "globwalk",
  "ignore",
+ "is-terminal",
  "man",
  "memmap2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ memmap2 = "0.5.10"
 tempfile = "3.2.0"
 thiserror = "1.0.24"
 globwalk = "0.8.1"
-atty = "0.2.14"
 ignore = "0.4.17"
 ansi_term = "0.12.1"
+is-terminal = "0.4.7"
 
 [dev-dependencies]
 assert_cmd = "1.0.3"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,5 @@
+use is_terminal::IsTerminal;
+
 use crate::{Replacer, Result};
 use std::{fs::File, io::prelude::*, path::PathBuf};
 
@@ -34,7 +36,7 @@ impl App {
         Self { source, replacer }
     }
     pub(crate) fn run(&self, preview: bool) -> Result<()> {
-        let is_tty = atty::is(atty::Stream::Stdout);
+        let is_tty = std::io::stdout().is_terminal();
 
         match (&self.source, preview) {
             (Source::Stdin, _) => {


### PR DESCRIPTION
`atty` has a minor soundness issue and is no longer maintained, so replace with `is-terminal`. In the future we can switch to using the functionality from std