### PR TITLE
Rename `--string-mode` to `--fixed-strings`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,7 +24,7 @@ pub struct Options {
         short_alias = 's',
         alias = "string-mode"
     )]
-    /// Treat expressions as non-regex strings.
+    /// Treat FIND and REPLACE_WITH args as literal strings
     pub literal_mode: bool,
 
     #[arg(short)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,12 @@ pub struct Options {
     /// Output result into stdout and do not modify files.
     pub preview: bool,
 
-    #[arg(short = 's', long = "string-mode")]
+    #[arg(
+        short = 'F',
+        long = "fixed-strings",
+        short_alias = 's',
+        alias = "string-mode"
+    )]
     /// Treat expressions as non-regex strings.
     pub literal_mode: bool,
 


### PR DESCRIPTION
Resolves #104
Resolves #46


This follows the naming of other tools in the same space while keeping an alias to keep existing usage of `-s` and `--string-mode` the same