### PR TITLE
add --no-swap flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ w - match full words only
     /// use captured values like $1, $2, etc.
     pub replace_with: String,
 
+    #[arg(long)]
+    /// Overwrite file instead of creating tmp file and swaping atomically
+    pub no_swap: bool,
+
     /// The path to file(s). This is optional - sd can also read from STDIN.
     ///{n}{n}Note: sd modifies files in-place by default. See documentation for
     /// examples.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn main() -> Result<()> {
             options.literal_mode,
             options.flags,
             options.replacements,
+            options.no_swap,
         )?,
     )
     .run(options.preview)?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,7 @@
 mod cli {
     use anyhow::Result;
     use assert_cmd::Command;
+    use rstest::rstest;
     use std::io::prelude::*;
 
     fn sd() -> Command {
@@ -25,36 +26,46 @@ mod cli {
         Ok(())
     }
 
-    #[test]
-    fn in_place() -> Result<()> {
+    #[rstest]
+    fn in_place(#[values(false, true)] no_swap: bool) -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write_all(b"abc123def")?;
         let path = file.into_temp_path();
 
-        sd().args(["abc\\d+", "", path.to_str().unwrap()])
-            .assert()
-            .success();
+        let mut cmd = sd();
+        cmd.args(["abc\\d+", "", path.to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success();
         assert_file(&path, "def");
 
         Ok(())
     }
 
-    #[test]
-    fn in_place_with_empty_result_file() -> Result<()> {
+    #[rstest]
+    fn in_place_with_empty_result_file(
+        #[values(false, true)] no_swap: bool,
+    ) -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write_all(b"a7c")?;
         let path = file.into_temp_path();
 
-        sd().args(["a\\dc", "", path.to_str().unwrap()])
-            .assert()
-            .success();
+        let mut cmd = sd();
+        cmd.args(["a\\dc", "", path.to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success();
         assert_file(&path, "");
 
         Ok(())
     }
 
-    #[test]
-    fn in_place_following_symlink() -> Result<()> {
+    #[rstest]
+    fn in_place_following_symlink(
+        #[values(false, true)] no_swap: bool,
+    ) -> Result<()> {
         let dir = tempfile::tempdir()?;
         let path = dir.path();
         let file = path.join("file");
@@ -63,9 +74,12 @@ mod cli {
         create_soft_link(&file, &link)?;
         std::fs::write(&file, "abc123def")?;
 
-        sd().args(["abc\\d+", "", link.to_str().unwrap()])
-            .assert()
-            .success();
+        let mut cmd = sd();
+        cmd.args(["abc\\d+", "", link.to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success();
 
         assert_file(&file, "def");
         assert!(std::fs::symlink_metadata(link)?.file_type().is_symlink());
@@ -73,29 +87,35 @@ mod cli {
         Ok(())
     }
 
-    #[test]
-    fn replace_into_stdout() -> Result<()> {
+    #[rstest]
+    fn replace_into_stdout(#[values(false, true)] no_swap: bool) -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write_all(b"abc123def")?;
 
-        sd().args(["-p", "abc\\d+", "", file.path().to_str().unwrap()])
-            .assert()
-            .success()
-            .stdout(format!(
-                "{}{}def\n",
-                ansi_term::Color::Green.prefix(),
-                ansi_term::Color::Green.suffix()
-            ));
+        let mut cmd = sd();
+        cmd.args(["-p", "abc\\d+", "", file.path().to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success().stdout(format!(
+            "{}{}def\n",
+            ansi_term::Color::Green.prefix(),
+            ansi_term::Color::Green.suffix()
+        ));
 
         assert_file(file.path(), "abc123def");
 
         Ok(())
     }
 
-    #[test]
-    fn stdin() -> Result<()> {
-        sd().args(["abc\\d+", ""])
-            .write_stdin("abc123def")
+    #[rstest]
+    fn stdin(#[values(false, true)] no_swap: bool) -> Result<()> {
+        let mut cmd = sd();
+        cmd.args(["abc\\d+", ""]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.write_stdin("abc123def")
             .assert()
             .success()
             .stdout("def");


### PR DESCRIPTION
See #191 for details

I gave it a shot. Tell me what you think :)

I've also parameterized the tests so the flag is also tested for the same cases.

I did some hyperfine benchmarks to make sure performance isn't severely degraded and it's mostly the same:
```
$ hyperfine -N -w1 -p 'cp source.txt test.txt' "/home/manu/dev/stuff/sd/target/debug/sd foo bar test.txt" "/home/manu/dev/stuff/sd/target/debug/sd --no-swap foo bar test.txt"
```
(tried with input sizes: 10B, 1KB, 10MB and containing `foo` on each line)