### PR TITLE
Add library crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.2.7", features = ["derive", "deprecated", "wrap_help"] }
 [dev-dependencies]
 assert_cmd = "1.0.3"
 anyhow = "1.0.38"
+rstest = "0.17.0"
 
 [build-dependencies]
 clap = "4.2.7"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ w - match full words only
     /// use captured values like $1, $2, etc.
     pub replace_with: String,
 
+    #[arg(long)]
+    /// Overwrite file instead of creating tmp file and swaping atomically
+    pub no_swap: bool,
+
     /// The path to file(s). This is optional - sd can also read from STDIN.
     ///{n}{n}Note: sd modifies files in-place by default. See documentation for
     /// examples.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,8 @@ w - match full words only
     pub no_swap: bool,
 
     /// The path to file(s). This is optional - sd can also read from STDIN.
-    ///{n}{n}Note: sd modifies files in-place by default. See documentation for
+    /// 
+    /// Note: sd modifies files in-place by default. See documentation for
     /// examples.
     pub files: Vec<std::path::PathBuf>,
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,14 +4,31 @@ use crate::{Error, Replacer, Result};
 
 use is_terminal::IsTerminal;
 
+/// The source files we regard as the input.
 #[derive(Debug)]
-pub(crate) enum Source {
+pub enum Source {
     Stdin,
     Files(Vec<PathBuf>),
 }
 
 impl Source {
-    pub(crate) fn recursive() -> Result<Self> {
+    pub fn with_file<T>(file: T) -> Self
+        where T: Into<PathBuf>
+    {
+        Self::with_files(vec![file])
+    }
+
+    pub fn with_files<T>(files: Vec<T>) -> Self
+        where T: Into<PathBuf>
+    {
+        Self::Files(
+            files.into_iter()
+                .map(|file_path| file_path.into())
+                .collect()
+        )
+    }
+
+    pub fn recursive() -> Result<Self> {
         Ok(Self::Files(
             ignore::WalkBuilder::new(".")
                 .hidden(false)
@@ -36,6 +53,7 @@ impl App {
     pub(crate) fn new(source: Source, replacer: Replacer) -> Self {
         Self { source, replacer }
     }
+
     pub(crate) fn run(&self, preview: bool) -> Result<()> {
         let is_tty = std::io::stdout().is_terminal();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod input;
 pub mod error;
+pub mod input;
 pub mod replacer;
 pub mod utils;
 
@@ -17,6 +17,10 @@ pub struct ReplaceConf {
     pub replacements: Option<usize>,
 }
 
+pub struct ReplaceConfBuilder {
+    inner: ReplaceConf,
+}
+
 impl Default for ReplaceConf {
     fn default() -> Self {
         Self {
@@ -30,20 +34,49 @@ impl Default for ReplaceConf {
     }
 }
 
+impl ReplaceConf {
+    pub fn builder() -> ReplaceConfBuilder {
+        ReplaceConfBuilder {
+            inner: Self::default(),
+        }
+    }
+}
+
+impl ReplaceConfBuilder {
+    pub fn set_source(mut self, source: Source) -> Self {
+        self.inner.source = source;
+        self
+    }
+
+    pub fn build(self) -> ReplaceConf {
+        self.inner
+    }
+}
+
 /// For example:
-/// 
+///
 /// ```no_run
+/// use sd::{replace, ReplaceConf, Source};
+/// 
 /// replace("foo", "bar", ReplaceConf {
 ///     source: Source::with_files(vec!["./foo.md", "./bar.md", "./foobar.md"]),
 ///     ..ReplaceConf::default()
-/// })
+/// });
 /// ```
-pub fn replace(find: String, replace_with: String, replace_conf: ReplaceConf) -> Result<()> {
+pub fn replace<F, R>(
+    find: F,
+    replace_with: R,
+    replace_conf: ReplaceConf,
+) -> Result<()>
+where
+    F: Into<String>,
+    R: Into<String>,
+{
     App::new(
         replace_conf.source,
         Replacer::new(
-            find,
-            replace_with,
+            find.into(),
+            replace_with.into(),
             replace_conf.literal_mode,
             replace_conf.flags,
             replace_conf.replacements,
@@ -52,4 +85,35 @@ pub fn replace(find: String, replace_with: String, replace_conf: ReplaceConf) ->
     )
     .run(replace_conf.preview)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::{File, self}, io::{Write, Read}};
+
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        // Create files for test.
+        for p in &vec!["./for-test-foo", "./for-test-bar"] {
+            let mut f = File::create(p).unwrap();
+            f.write_all(b"foo bar foz").unwrap();
+        }
+
+        // Run it.
+        let replace_conf = ReplaceConf::builder()
+                .set_source(Source::with_files(vec!["./for-test-foo", "./for-test-bar"]))
+                .build();
+        replace("foo", "bar", replace_conf).unwrap();
+
+        // Assert and cleanup.
+        for p in &vec!["./for-test-foo", "./for-test-bar"] {
+            let mut f = File::open(p).unwrap();
+            let mut buf = vec![];
+            f.read_to_end(&mut buf).unwrap();
+            assert_eq!(buf, b"bar bar foz");
+            fs::remove_file(p).unwrap();
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,55 @@
+pub mod input;
+pub mod error;
+pub mod replacer;
+pub mod utils;
+
+pub use self::input::Source;
+pub use error::{Error, Result};
+use input::App;
+pub(crate) use replacer::Replacer;
+
+pub struct ReplaceConf {
+    pub source: Source,
+    pub preview: bool,
+    pub no_swap: bool,
+    pub literal_mode: bool,
+    pub flags: Option<String>,
+    pub replacements: Option<usize>,
+}
+
+impl Default for ReplaceConf {
+    fn default() -> Self {
+        Self {
+            source: Source::Stdin,
+            preview: false,
+            no_swap: false,
+            literal_mode: false,
+            flags: None,
+            replacements: None,
+        }
+    }
+}
+
+/// For example:
+/// 
+/// ```no_run
+/// replace("foo", "bar", ReplaceConf {
+///     source: Source::with_files(vec!["./foo.md", "./bar.md", "./foobar.md"]),
+///     ..ReplaceConf::default()
+/// })
+/// ```
+pub fn replace(find: String, replace_with: String, replace_conf: ReplaceConf) -> Result<()> {
+    App::new(
+        replace_conf.source,
+        Replacer::new(
+            find,
+            replace_with,
+            replace_conf.literal_mode,
+            replace_conf.flags,
+            replace_conf.replacements,
+            replace_conf.no_swap,
+        )?,
+    )
+    .run(replace_conf.preview)?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn main() -> Result<()> {
             options.literal_mode,
             options.flags,
             options.replacements,
+            options.no_swap,
         )?,
     )
     .run(options.preview)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,8 @@
 mod cli;
-mod error;
-mod input;
-
-pub(crate) mod replacer;
-pub(crate) mod utils;
-
-pub(crate) use self::input::{App, Source};
-pub(crate) use error::{Error, Result};
-use replacer::Replacer;
 
 use clap::Parser;
+
+use sd::{Result, Source, replace, ReplaceConf};
 
 fn main() -> Result<()> {
     let options = cli::Options::parse();
@@ -22,17 +15,13 @@ fn main() -> Result<()> {
         Source::Stdin
     };
 
-    App::new(
+    replace(options.find, options.replace_with, ReplaceConf {
         source,
-        Replacer::new(
-            options.find,
-            options.replace_with,
-            options.literal_mode,
-            options.flags,
-            options.replacements,
-            options.no_swap,
-        )?,
-    )
-    .run(options.preview)?;
+        preview: options.preview,
+        no_swap: options.no_swap,
+        literal_mode: options.literal_mode,
+        flags: options.flags,
+        replacements: options.replacements,
+    })?;
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,7 @@
 mod cli {
     use anyhow::Result;
     use assert_cmd::Command;
+    use rstest::rstest;
     use std::io::prelude::*;
 
     fn sd() -> Command {
@@ -25,36 +26,46 @@ mod cli {
         Ok(())
     }
 
-    #[test]
-    fn in_place() -> Result<()> {
+    #[rstest]
+    fn in_place(#[values(false, true)] no_swap: bool) -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write_all(b"abc123def")?;
         let path = file.into_temp_path();
 
-        sd().args(["abc\\d+", "", path.to_str().unwrap()])
-            .assert()
-            .success();
+        let mut cmd = sd();
+        cmd.args(["abc\\d+", "", path.to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success();
         assert_file(&path, "def");
 
         Ok(())
     }
 
-    #[test]
-    fn in_place_with_empty_result_file() -> Result<()> {
+    #[rstest]
+    fn in_place_with_empty_result_file(
+        #[values(false, true)] no_swap: bool,
+    ) -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write_all(b"a7c")?;
         let path = file.into_temp_path();
 
-        sd().args(["a\\dc", "", path.to_str().unwrap()])
-            .assert()
-            .success();
+        let mut cmd = sd();
+        cmd.args(["a\\dc", "", path.to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success();
         assert_file(&path, "");
 
         Ok(())
     }
 
-    #[test]
-    fn in_place_following_symlink() -> Result<()> {
+    #[rstest]
+    fn in_place_following_symlink(
+        #[values(false, true)] no_swap: bool,
+    ) -> Result<()> {
         let dir = tempfile::tempdir()?;
         let path = dir.path();
         let file = path.join("file");
@@ -63,9 +74,12 @@ mod cli {
         create_soft_link(&file, &link)?;
         std::fs::write(&file, "abc123def")?;
 
-        sd().args(["abc\\d+", "", link.to_str().unwrap()])
-            .assert()
-            .success();
+        let mut cmd = sd();
+        cmd.args(["abc\\d+", "", link.to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success();
 
         assert_file(&file, "def");
         assert!(std::fs::symlink_metadata(link)?.file_type().is_symlink());
@@ -73,29 +87,35 @@ mod cli {
         Ok(())
     }
 
-    #[test]
-    fn replace_into_stdout() -> Result<()> {
+    #[rstest]
+    fn replace_into_stdout(#[values(false, true)] no_swap: bool) -> Result<()> {
         let mut file = tempfile::NamedTempFile::new()?;
         file.write_all(b"abc123def")?;
 
-        sd().args(["-p", "abc\\d+", "", file.path().to_str().unwrap()])
-            .assert()
-            .success()
-            .stdout(format!(
-                "{}{}def\n",
-                ansi_term::Color::Green.prefix(),
-                ansi_term::Color::Green.suffix()
-            ));
+        let mut cmd = sd();
+        cmd.args(["-p", "abc\\d+", "", file.path().to_str().unwrap()]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.assert().success().stdout(format!(
+            "{}{}def\n",
+            ansi_term::Color::Green.prefix(),
+            ansi_term::Color::Green.suffix()
+        ));
 
         assert_file(file.path(), "abc123def");
 
         Ok(())
     }
 
-    #[test]
-    fn stdin() -> Result<()> {
-        sd().args(["abc\\d+", ""])
-            .write_stdin("abc123def")
+    #[rstest]
+    fn stdin(#[values(false, true)] no_swap: bool) -> Result<()> {
+        let mut cmd = sd();
+        cmd.args(["abc\\d+", ""]);
+        if no_swap {
+            cmd.arg("--no-swap");
+        }
+        cmd.write_stdin("abc123def")
             .assert()
             .success()
             .stdout("def");


### PR DESCRIPTION
This PR is based on #193. So do not merge me before when #193 is merged, please.

This PR is going to solve #194. It supports users can:

```rust
sd::replace("foo", "bar", sd::ReplaceConf {
    source: sd::Source::with_files(vec!["./foo.md", "./bar.md"]),
    ..sd::ReplaceConf::default(),
})
```

Maybe using a builder is a great idea? And I also need more tests for it.

Your advice is important to me, @CosmicHorrorDev and @fujidaiti. What do you think?