### PR TITLE
Move generating static assets to a `cargo-xtask` task

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
       if: ${{ matrix.use-cross == true }}
       shell: bash
       run: |
-           mkdir .cargo
            cat > .cargo/config.toml <<EOF
            [target.${{ matrix.target }}]
            rustflags = ["--cfg", "sd_cross_compile"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
@@ -170,18 +170,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.2.2"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36774babb166352bb4f7b9cb16f781ffa3439d2a8f12cd31bea85a38c888fea3"
+checksum = "7f6b5c519bab3ea61843a7923d074b04245624bb84a64a8c150f5deb014e388b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -913,3 +913,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "man",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [
+    ".",
+    "xtask",
+]
+
 [package]
 name = "sd"
 version = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,6 @@ clap = { version = "4.2.7", features = ["derive", "deprecated", "wrap_help"] }
 assert_cmd = "1.0.3"
 anyhow = "1.0.38"
 
-[build-dependencies]
-clap = "4.2.7"
-clap_complete = "4.2.2"
-man = "0.3.0"
-
 [profile.release]
 opt-level = 3
 lto = true

--- a/gen/completions/_sd
+++ b/gen/completions/_sd
@@ -1,0 +1,46 @@
+#compdef sd
+
+autoload -U is-at-least
+
+_sd() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" \
+'-n+[Limit the number of replacements]:REPLACEMENTS: ' \
+'-f+[Regex flags. May be combined (like \`-f mc\`).]:FLAGS: ' \
+'--flags=[Regex flags. May be combined (like \`-f mc\`).]:FLAGS: ' \
+'-p[Output result into stdout and do not modify files]' \
+'--preview[Output result into stdout and do not modify files]' \
+'-F[Treat FIND and REPLACE_WITH args as literal strings]' \
+'--fixed-strings[Treat FIND and REPLACE_WITH args as literal strings]' \
+'-r[Recursively replace files]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+'-V[Print version]' \
+'--version[Print version]' \
+':find -- The regexp or string (if -s) to search for:' \
+':replace_with -- What to replace each match with. Unless in string mode, you may use captured values like $1, $2, etc:' \
+'*::files -- The path to file(s). This is optional - sd can also read from STDIN. {n}{n}Note\: sd modifies files in-place by default. See documentation for examples:_files' \
+&& ret=0
+}
+
+(( $+functions[_sd_commands] )) ||
+_sd_commands() {
+    local commands; commands=()
+    _describe -t commands 'sd commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_sd" ]; then
+    _sd "$@"
+else
+    compdef _sd sd
+fi

--- a/gen/completions/_sd.ps1
+++ b/gen/completions/_sd.ps1
@@ -1,0 +1,42 @@
+
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'sd' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'sd'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-') -or
+                $element.Value -eq $wordToComplete) {
+                break
+        }
+        $element.Value
+    }) -join ';'
+
+    $completions = @(switch ($command) {
+        'sd' {
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Limit the number of replacements')
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Regex flags. May be combined (like `-f mc`).')
+            [CompletionResult]::new('--flags', 'flags', [CompletionResultType]::ParameterName, 'Regex flags. May be combined (like `-f mc`).')
+            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Output result into stdout and do not modify files')
+            [CompletionResult]::new('--preview', 'preview', [CompletionResultType]::ParameterName, 'Output result into stdout and do not modify files')
+            [CompletionResult]::new('-F', 'F', [CompletionResultType]::ParameterName, 'Treat FIND and REPLACE_WITH args as literal strings')
+            [CompletionResult]::new('--fixed-strings', 'fixed-strings', [CompletionResultType]::ParameterName, 'Treat FIND and REPLACE_WITH args as literal strings')
+            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'Recursively replace files')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version')
+            break
+        }
+    })
+
+    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
+        Sort-Object -Property ListItemText
+}

--- a/gen/completions/sd.bash
+++ b/gen/completions/sd.bash
@@ -1,0 +1,50 @@
+_sd() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd=""
+    opts=""
+
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="sd"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        sd)
+            opts="-p -F -r -n -f -h -V --preview --fixed-strings --flags --help --version <FIND> <REPLACE_WITH> [FILES]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --flags)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -f)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+complete -F _sd -o bashdefault -o default sd

--- a/gen/completions/sd.elv
+++ b/gen/completions/sd.elv
@@ -1,0 +1,36 @@
+
+use builtin;
+use str;
+
+set edit:completion:arg-completer[sd] = {|@words|
+    fn spaces {|n|
+        builtin:repeat $n ' ' | str:join ''
+    }
+    fn cand {|text desc|
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
+    }
+    var command = 'sd'
+    for word $words[1..-1] {
+        if (str:has-prefix $word '-') {
+            break
+        }
+        set command = $command';'$word
+    }
+    var completions = [
+        &'sd'= {
+            cand -n 'Limit the number of replacements'
+            cand -f 'Regex flags. May be combined (like `-f mc`).'
+            cand --flags 'Regex flags. May be combined (like `-f mc`).'
+            cand -p 'Output result into stdout and do not modify files'
+            cand --preview 'Output result into stdout and do not modify files'
+            cand -F 'Treat FIND and REPLACE_WITH args as literal strings'
+            cand --fixed-strings 'Treat FIND and REPLACE_WITH args as literal strings'
+            cand -r 'Recursively replace files'
+            cand -h 'Print help (see more with ''--help'')'
+            cand --help 'Print help (see more with ''--help'')'
+            cand -V 'Print version'
+            cand --version 'Print version'
+        }
+    ]
+    $completions[$command]
+}

--- a/gen/completions/sd.fish
+++ b/gen/completions/sd.fish
@@ -1,0 +1,7 @@
+complete -c sd -s n -d 'Limit the number of replacements' -r
+complete -c sd -s f -l flags -d 'Regex flags. May be combined (like `-f mc`).' -r
+complete -c sd -s p -l preview -d 'Output result into stdout and do not modify files'
+complete -c sd -s F -l fixed-strings -d 'Treat FIND and REPLACE_WITH args as literal strings'
+complete -c sd -s r -d 'Recursively replace files'
+complete -c sd -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c sd -s V -l version -d 'Print version'

--- a/gen/sd.1
+++ b/gen/sd.1
@@ -1,0 +1,63 @@
+.TH SD 1
+.SH NAME
+sd
+.SH SYNOPSIS
+\fBsd\fR [FLAGS] find replace_with [FILES]
+.SH FLAGS
+.TP
+\fB\-p\fR, \fB\-\-preview\fR
+Emit the replacement to STDOUT
+
+.TP
+\fB\-s\fR, \fB\-\-string\-mode\fR
+Treat expressions as non\-regex strings.
+
+.TP
+\fB\-f\fR, \fB\-\-flags\fR
+Regex flags. May be combined (like `\-f mc`).
+
+c \- case\-sensitive
+i \- case\-insensitive
+m \- multi\-line matching
+w \- match full words only
+
+.SH EXIT STATUS
+.TP
+\fB0\fR
+Successful program execution.
+
+.TP
+\fB1\fR
+Unsuccessful program execution.
+
+.TP
+\fB101\fR
+The program panicked.
+.SH EXAMPLES
+.TP
+String\-literal mode
+\fB$ echo 'lots((([]))) of special chars' | sd \-s '((([])))' ''\fR
+.br
+lots of special chars
+.TP
+Regex use. Let's trim some trailing whitespace
+\fB$ echo 'lorem ipsum 23   ' | sd '\s+$' ''\fR
+.br
+lorem ipsum 23
+.TP
+Indexed capture groups
+\fB$ echo 'cargo +nightly watch' | sd '(\w+)\s+\+(\w+)\s+(\w+)' 'cmd: $1, channel: $2, subcmd: $3'\fR
+.br
+cmd: cargo, channel: nightly, subcmd: watch
+.TP
+Named capture groups
+\fB$ echo "123.45" | sd '(?P<dollars>\d+)\.(?P<cents>\d+)' '$dollars dollars and $cents cents'\fR
+.br
+123 dollars and 45 cents
+.TP
+Find & replace in file
+\fB$ sd 'window.fetch' 'fetch' http.js\fR
+.TP
+Find & replace from STDIN an emit to STDOUT
+\fB$ sd 'window.fetch' 'fetch' < http.js\fR
+

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = "4.3.1"
+clap_complete = "4.3.1"
+man = "0.3.0"

--- a/xtask/src/gen.rs
+++ b/xtask/src/gen.rs
@@ -1,25 +1,30 @@
-include!("src/cli.rs");
+include!("../../src/cli.rs");
 
-fn main() {
-    use std::{env::var, fs};
+use std::{fs, path::Path};
 
-    use clap::{CommandFactory, ValueEnum};
-    use clap_complete::{generate_to, Shell};
+use clap::{CommandFactory, ValueEnum};
+use clap_complete::{generate_to, Shell};
+use man::prelude::*;
 
-    let out_dir = var("SHELL_COMPLETIONS_DIR").or(var("OUT_DIR")).unwrap();
+pub fn gen() {
+    let gen_dir = Path::new("gen");
+    gen_shell(gen_dir);
+    gen_man(gen_dir);
+}
 
-    fs::create_dir_all(&out_dir).unwrap();
+fn gen_shell(base_dir: &Path) {
+    let completions_dir = base_dir.join("completions");
+    fs::create_dir_all(&completions_dir).unwrap();
 
     let mut cmd = Options::command();
     for &shell in Shell::value_variants() {
-        generate_to(shell, &mut cmd, "sd", &out_dir).unwrap();
+        generate_to(shell, &mut cmd, "sd", &completions_dir).unwrap();
     }
-
-    create_man_page();
 }
 
-fn create_man_page() {
-    use man::prelude::*;
+fn gen_man(base_dir: &Path) {
+    let man_path = base_dir.join("sd.1");
+
     let page = Manual::new("sd")
         .flag(
             Flag::new()
@@ -84,8 +89,5 @@ w - match full words only
         )
         .render();
 
-    let mut man_path =
-        std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
-    man_path.push("sd.1");
-    std::fs::write(man_path, page).expect("Error writing man page");
+    std::fs::write(man_path, page).unwrap();
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,41 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use clap::{Parser, Subcommand};
+
+mod gen;
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate static assets
+    Gen,
+}
+
+fn main() {
+    let Cli { command } = Cli::parse();
+
+    env::set_current_dir(project_root()).unwrap();
+
+    match command {
+        Commands::Gen => gen::gen(),
+    }
+}
+
+fn project_root() -> PathBuf {
+    Path::new(
+        &env::var("CARGO_MANIFEST_DIR")
+            .unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_owned()),
+    )
+    .ancestors()
+    .nth(1)
+    .unwrap()
+    .to_path_buf()
+}


### PR DESCRIPTION
Moves generating both the shell completions and man page to a [`cargo-xtask`](https://github.com/matklad/cargo-xtask) task

This means that the task will have to be manually run to regenerate the assets, but it also gets rid of the build dependencies