### PR TITLE
Resolving broken `aarch64-apple-darwin` tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            use-cross: true
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: true
+            use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: true
+            use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -30,10 +32,9 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
-          # This isn't working right now. See this: https://github.com/chmln/sd/pull/179#discussion_r1195840870
-          # - os: macos-latest
-          #   target: aarch64-apple-darwin
-          #   use-cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,11 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            use-cross: false
+          # For legal reasons, cross doesn't support Apple Silicon. See this: https://github.com/cross-rs/cross-toolchains#darwin-targets
+          # It builds and runs fine, but there's no convenient way to test it in CI, ATM.
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
+          #   use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            use-cross: true
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl


### PR DESCRIPTION
Hopefully this just works first try for no apparent reason, despite failing for no apparent reason in #179 .

If it doesn't, I'll try to resolve the broken test.

This PR also includes an additional configuration that allows the test to be run via workflow dispatch. This will allow anyone with write permissions to run the tests ad-hoc on their own forks.