### PR TITLE
docs: use clap_mangen and roff to generate manpage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44f35c514163027542f7147797ff930523eea288e03642727348ef1a9666f6b"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,15 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "man"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf5fa795187a80147b1ac10aaedcf5ffd3bbeb1838bda61801a1c9ad700a1c9"
-dependencies = [
- "roff",
-]
-
-[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,9 +555,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "roff"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33e4fb37ba46888052c763e4ec2acfedd8f00f62897b630cadb6298b833675e"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustix"
@@ -608,6 +609,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_mangen",
  "globwalk",
  "ignore",
  "is-terminal",
@@ -837,9 +839,10 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.7.6"
 dependencies = [
  "clap",
  "clap_complete",
- "man",
+ "clap_mangen",
+ "roff",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+package.version = "0.7.6"
 members = [
     ".",
     "xtask",
@@ -6,7 +7,7 @@ members = [
 
 [package]
 name = "sd"
-version = "0.7.6"
+version.workspace = true
 edition = "2018"
 authors = ["Gregory <gregory.mkv@gmail.com>"]
 description = "An intuitive find & replace CLI"
@@ -33,6 +34,7 @@ clap = { version = "4.4.3", features = ["derive", "deprecated", "wrap_help"] }
 [dev-dependencies]
 assert_cmd = "2.0.12"
 anyhow = "1.0.75"
+clap_mangen = "0.2.14"
 
 [profile.release]
 opt-level = 3

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(
+    name = "sd",
     author,
     version,
     about,
@@ -40,10 +41,15 @@ pub struct Options {
     /** Regex flags. May be combined (like `-f mc`).
 
 c - case-sensitive
+
 e - disable multi-line matching
+
 i - case-insensitive
+
 m - multi-line matching
+
 s - make `.` match newlines
+
 w - match full words only
     */
     pub flags: Option<String>,
@@ -56,7 +62,8 @@ w - match full words only
     pub replace_with: String,
 
     /// The path to file(s). This is optional - sd can also read from STDIN.
-    ///{n}{n}Note: sd modifies files in-place by default. See documentation for
+    ///
+    /// Note: sd modifies files in-place by default. See documentation for
     /// examples.
     pub files: Vec<std::path::PathBuf>,
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 publish = false
 
 [dependencies]
 clap = "4.4.3"
 clap_complete = "4.4.1"
-man = "0.3.0"
+clap_mangen = "0.2.14"
+roff = "0.2.1"


### PR DESCRIPTION
Fixes https://github.com/chmln/sd/issues/226. `cargo xtask gen && man gen/sd.1` to try it out.

I *think* this also fixes (?) https://github.com/chmln/sd/issues/134, including list of flags and its formatting, and return codes. Unfornutaly clap_mangen has no custom section support (yet), so I've learned from https://github.com/clap-rs/clap/issues/3579 and used roff to make the EXIT STATUSES and EXAMPLES sections.

Note that the list of flags formatting is "fixed" with separating each flag into its own paragraph, but that should be tolerable I guess.