### PR TITLE
Tone down dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
All the PRs are starting to fall more towards noise and less towards signal on the signal to noise ratio. Updating dependencies can be done before a release instead of bumping with every single version