### PR TITLE
Exclude unsupported packages from the repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Install through
 [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html) with
 `cargo install sd`, or through various package managers
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/sd-find-replace.svg)](https://repology.org/project/sd-find-replace/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/sd-find-replace.svg?exclude_unsupported=1)](https://repology.org/project/sd-find-replace/versions)
 
 ## Quick Guide
 


### PR DESCRIPTION
`sd` is decently old at this point, so the repology badge gets a bit cluttered with no longer supported packages. This switches the badge to exclude those