### PR TITLE
Update sd to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "sd"
 version.workspace = true
-edition = "2018"
+edition = "2021"
 authors = ["Gregory <gregory.mkv@gmail.com>"]
 description = "An intuitive find & replace CLI"
 readme = "README.md"


### PR DESCRIPTION
https://github.com/chmln/sd/issues/244

as per [the guidelines](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)

- [x] Ran `cargo fix --edition`
- [x] Updated the Cargo.toml
- [x] Cargo test and cargo build are working fine