### PR TITLE
Remove broken custom path separator flag

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,13 +54,6 @@ w - match full words only
     */
     pub flags: Option<String>,
 
-    #[arg(long, value_name = "SEPARATOR")]
-    /// Set the path separator to use when printing file paths. The default is
-    /// your platform's path separator ('/' on Unix, '\' on Windows). This flag
-    /// is intended to override the default when the environment demands it. A
-    /// path separator is limited to a single byte.
-    pub path_separator: Option<char>,
-
     /// The regexp or string (if using `-F`) to search for.
     pub find: String,
 


### PR DESCRIPTION
This accidentally got included in some other changes. I'm still planning on adding this flag, so that the file paths that get displayed with the `--preview` flag can look right on git bash, but that can wait till after release.