### PR TITLE
More CI tweaks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,10 +98,27 @@ jobs:
           echo "BIN_NAME=sd" >> $GITHUB_ENV
         fi
 
+    - name: Setup archive
+      shell: bash
+      run: |
+        staging="sd-${{ env.SD_VERSION }}-${{ matrix.target }}"
+        mkdir -p "$staging"
+
+        cp -r {README.md,LICENSE,gen/*} "$staging"
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          cp "target/${{ matrix.target }}/release/sd.exe" "$staging/"
+          7z a "$staging.zip" "$staging"
+          echo "ASSET=$staging.zip" >> $GITHUB_ENV
+        else
+          cp "target/${{ matrix.target }}/release-lto/inlyne" "$staging/"
+          tar czf "$staging.tar.gz" "$staging"
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+        fi
+
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@2.7.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.target }}/release/${{ env.BIN_NAME }}
-        asset_name: sd-${{ env.SD_VERSION }}-${{ matrix.target }}
+        file: ${{ env.ASSET }}
+        asset_name: ${{ env.ASSET }}
         tag: ${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,9 @@ jobs:
             target: x86_64-apple-darwin
             use-cross: false
 
-          # For legal reasons, cross doesn't support Apple Silicon. See this: https://github.com/cross-rs/cross-toolchains#darwin-targets
-          # It builds and runs fine, but there's no convenient way to test it in CI, ATM.
-          # - os: macos-latest
-          #   target: aarch64-apple-darwin
-          #   use-cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
 
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
@@ -84,4 +82,11 @@ jobs:
       shell: bash
       run: |
         $CARGO --version
-        $CARGO test --target ${{ matrix.target }}
+          # For legal reasons, cross doesn't support Apple Silicon. See this:
+          # https://github.com/cross-rs/cross-toolchains#darwin-targets
+          # It builds and runs fine, but there's no easy way to test it in CI
+        if [ "${{ matrix.target }}" = "aarch64-apple-darwin" ]; then
+          $CARGO build --target ${{ matrix.target }}
+        else
+          $CARGO test --target ${{ matrix.target }}
+        fi


### PR DESCRIPTION
Two more changes:

- Re-enables building the ARM mac target just to make sure that it doesn't break without us knowing
- Includes the man page, README, and completions in the pre-built releases