### PR TITLE
Remove warning when using `--preview` on stdin input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -58,10 +58,7 @@ impl App {
         let is_tty = std::io::stdout().is_terminal();
 
         match (&self.source, preview) {
-            (Source::Stdin, true) => {
-                eprintln!("WARN: `--preview` flag is redundant");
-                self.stdin_replace(is_tty)
-            }
+            (Source::Stdin, true) => self.stdin_replace(is_tty),
             (Source::Stdin, false) => self.stdin_replace(is_tty),
             (Source::Files(paths), false) => {
                 use rayon::prelude::*;


### PR DESCRIPTION
This reverts #239 

I agreed with the motivation from the original PR, but I have since changed my mind. Currently using `--preview` when dealing with input from stdin is identical to not passing `--preview`, hence the idea behind the warning.

The reason that I changed my mind is that I now view those two matching to be just a coincidence. The output of `--preview` is likely to change in the future to be more human friendly while not passing `--preview` should always pass the full expected output so it can be piped to other programs, files, etc. Because this is likely to change in the future I don't think we should dissuade users from passing `--preview` while dealing with stdin input