### PR TITLE
Handle "-" in the beginning of patterns (fixes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,24 +158,6 @@ Install through
    fd --type file --exec cp {} {}.bk \; --exec sd 'from "react"' 'from "preact"'
    ```
 
-### Edge cases
-sd will interpret every argument starting with `-` as a (potentially unknown) flag.
-The common convention of using `--` to signal the end of flags is respected:
-
-```bash
-$ echo "./hello foo" | sd "foo" "-w"
-error: Found argument '-w' which wasn't expected, or isn't valid in this context
-
-USAGE:
-    sd [OPTIONS] <find> <replace-with> [files]...
-
-For more information try --help
-$ echo "./hello foo" | sd "foo" -- "-w"
-./hello -w
-$ echo "./hello --foo" | sd -- "--foo" "-w"
-./hello -w
-```
-
 ### Escaping special characters
 To escape the `$` character, use `$$`:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,10 +55,12 @@ w - match full words only
     pub flags: Option<String>,
 
     /// The regexp or string (if using `-F`) to search for.
+    #[arg(allow_hyphen_values = true)]
     pub find: String,
 
     /// What to replace each match with. Unless in string mode, you may
     /// use captured values like $1, $2, etc.
+    #[arg(allow_hyphen_values = true)]
     pub replace_with: String,
 
     /// The path to file(s). This is optional - sd can also read from STDIN.


### PR DESCRIPTION
The README makes an invalid statement that the arguments cannot start with "-". They can and it is [natively handled by Clap](https://docs.rs/clap/latest/clap/struct.Arg.html#method.allow_hyphen_values). With the fix, the patterns can start with "-". Of course, patterns like "-h" would be shadowed by the flags, so would need "--", e.g. `sd -- -h X` replaces "-h" with "X".