### PR TITLE
Update `--preview` help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,8 @@ use clap::Parser;
 )]
 pub struct Options {
     #[arg(short, long)]
-    /// Output result into stdout and do not modify files.
+    /// Display changes in a human reviewable format (the specifics of the
+    /// format are likely to change in the future).
     pub preview: bool,
 
     #[arg(


### PR DESCRIPTION
> From @dev-ardi 
> 
> In this case we should change the docs on the preview flag to something more descriptive. Right now it is
> 
> ```rust
> /// Output result into stdout and do not modify files.
> pub preview: bool,
> ```

Good catch! How does this look now?