### PR TITLE
Overall reorganization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,6 @@
+[*]
+indent_style = space
+indent_size = 4
+
 [*.rs]
 max_line_length = 80

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,7 +624,6 @@ name = "sd"
 version = "1.0.0"
 dependencies = [
  "ansi-to-html",
- "ansi_term",
  "anyhow",
  "assert_cmd",
  "clap",
@@ -786,28 +776,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,12 +325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "insta"
 version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,17 +335,6 @@ dependencies = [
  "linked-hash-map",
  "similar",
  "yaml-rust",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -657,7 +640,6 @@ dependencies = [
  "clap_mangen",
  "console",
  "insta",
- "is-terminal",
  "memmap2",
  "proptest",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ memmap2 = "0.9.0"
 tempfile = "3.8.0"
 thiserror = "1.0.50"
 ansi_term = "0.12.1"
-is-terminal = "0.4.9"
 clap.workspace = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ unescape = "0.1.0"
 memmap2 = "0.9.0"
 tempfile = "3.8.0"
 thiserror = "1.0.50"
-ansi_term = "0.12.1"
 clap.workspace = true
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     File(#[from] std::io::Error),
     #[error("failed to move file: {0}")]
     TempfilePersist(#[from] tempfile::PersistError),
-    #[error("file doesn't have parent path: {0}")]
+    #[error("invalid path: {0}")]
     InvalidPath(PathBuf),
     #[error("{0}")]
     InvalidReplaceCapture(#[from] InvalidReplaceCapture),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use crate::replacer::InvalidReplaceCapture;
 
@@ -14,13 +14,34 @@ pub enum Error {
     InvalidPath(PathBuf),
     #[error("{0}")]
     InvalidReplaceCapture(#[from] InvalidReplaceCapture),
+    #[error("{0}")]
+    FailedJobs(FailedJobs),
 }
 
 // pretty-print the error
-impl std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub struct FailedJobs(pub Vec<(PathBuf, Error)>);
+
+impl fmt::Display for FailedJobs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Failed processing some inputs\n")?;
+        for (source, error) in &self.0 {
+            writeln!(f, "    {}: {}", source.display(), error)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for FailedJobs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Write},
-    path::PathBuf,
-};
+use std::path::PathBuf;
 
 use crate::replacer::InvalidReplaceCapture;
 
@@ -15,28 +12,8 @@ pub enum Error {
     TempfilePersist(#[from] tempfile::PersistError),
     #[error("file doesn't have parent path: {0}")]
     InvalidPath(PathBuf),
-    #[error("failed processing files:\n{0}")]
-    FailedProcessing(FailedJobs),
     #[error("{0}")]
     InvalidReplaceCapture(#[from] InvalidReplaceCapture),
-}
-
-pub struct FailedJobs(Vec<(PathBuf, Error)>);
-
-impl From<Vec<(PathBuf, Error)>> for FailedJobs {
-    fn from(vec: Vec<(PathBuf, Error)>) -> Self {
-        Self(vec)
-    }
-}
-
-impl fmt::Display for FailedJobs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("\tFailedJobs(\n")?;
-        for (path, err) in &self.0 {
-            f.write_str(&format!("\t{:?}: {}\n", path, err))?;
-        }
-        f.write_char(')')
-    }
 }
 
 // pretty-print the error

--- a/src/input.rs
+++ b/src/input.rs
@@ -24,12 +24,12 @@ impl Source {
         vec![Self::Stdin]
     }
 
-	fn display(&self) -> String {
-		match self {
-			Self::Stdin => "STDIN".to_string(),
-			Self::File(path) => format!("FILE {}", path.display()),
-		}
-	}
+    fn display(&self) -> String {
+        match self {
+            Self::Stdin => "STDIN".to_string(),
+            Self::File(path) => format!("FILE {}", path.display()),
+        }
+    }
 }
 
 pub(crate) struct App {
@@ -47,9 +47,9 @@ impl App {
             .iter()
             .map(|source| (source, match source {
                 Source::File(path) => if path.exists() {
-					make_mmap(path)
-				} else {
-					Err(Error::InvalidPath(path.clone()))
+                    make_mmap(path)
+                } else {
+                    Err(Error::InvalidPath(path.clone()))
                 },
                 Source::Stdin => make_mmap_stdin()
             }))
@@ -116,7 +116,7 @@ fn make_mmap_stdin() -> Result<Mmap> {
 }
 
 fn write_with_temp(path: &PathBuf, data: &[u8]) -> Result<()> {
-	let path = fs::canonicalize(path)?;
+    let path = fs::canonicalize(path)?;
 
     let temp = tempfile::NamedTempFile::new_in(
         path.parent()
@@ -125,9 +125,9 @@ fn write_with_temp(path: &PathBuf, data: &[u8]) -> Result<()> {
 
     let file = temp.as_file();
     file.set_len(data.len() as u64)?;
-	if let Ok(metadata) = fs::metadata(&path) {
-	    file.set_permissions(metadata.permissions()).ok();
-	}
+    if let Ok(metadata) = fs::metadata(&path) {
+        file.set_permissions(metadata.permissions()).ok();
+    }
 
     if !data.is_empty() {
         let mut mmap_temp = unsafe { MmapMut::map_mut(file)? };

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,8 +26,11 @@ impl Source {
     }
 }
 
-pub(crate) fn make_mmap(path: &PathBuf) -> Result<Mmap> {
-    Ok(unsafe { Mmap::map(&File::open(path)?)? })
+// TODO: memmap2 docs state that users should implement proper
+// procedures to avoid problems the `unsafe` keyword indicate.
+// This would be in a later PR.
+pub(crate) unsafe fn make_mmap(path: &PathBuf) -> Result<Mmap> {
+    Ok(Mmap::map(&File::open(path)?)?)
 }
 
 pub(crate) fn make_mmap_stdin() -> Result<Mmap> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,13 +1,7 @@
-use std::{
-    fs::{self, File},
-    io::{stdin, stdout, Read, Write},
-    ops::DerefMut,
-    path::PathBuf,
-};
+use std::{path::PathBuf, fs::File, io::{stdin, Read}};
+use memmap2::{Mmap, MmapOptions};
 
-use crate::{Error, Replacer, Result};
-
-use memmap2::{Mmap, MmapMut, MmapOptions};
+use crate::error::Result;
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum Source {
@@ -24,7 +18,7 @@ impl Source {
         vec![Self::Stdin]
     }
 
-    fn display(&self) -> String {
+    pub(crate) fn display(&self) -> String {
         match self {
             Self::Stdin => "STDIN".to_string(),
             Self::File(path) => format!("FILE {}", path.display()),
@@ -32,80 +26,11 @@ impl Source {
     }
 }
 
-pub(crate) struct App {
-    replacer: Replacer,
-    sources: Vec<Source>,
-}
-
-impl App {
-    pub(crate) fn new(sources: Vec<Source>, replacer: Replacer) -> Self {
-        Self { sources, replacer }
-    }
-
-    pub(crate) fn run(&self, preview: bool) -> Result<()> {
-        let sources: Vec<(&Source, Result<Mmap>)> = self.sources
-            .iter()
-            .map(|source| (source, match source {
-                Source::File(path) => if path.exists() {
-                    make_mmap(path)
-                } else {
-                    Err(Error::InvalidPath(path.clone()))
-                },
-                Source::Stdin => make_mmap_stdin()
-            }))
-            .collect();
-        let needs_separator = sources.len() > 1;
-
-        let replaced: Vec<_> = {
-            use rayon::prelude::*;
-            sources
-                .par_iter()
-                .map(|(source, maybe_mmap)| (source, maybe_mmap.as_ref().map(|mmap| self.replacer.replace(mmap))))
-                .collect()
-        };
-
-        let mut errors = Vec::new();
-
-        if preview || self.sources.get(0) == Some(&Source::Stdin) {
-            let mut handle = stdout().lock();
-
-            for (source, replaced) in replaced.iter().filter(|(_, r)| r.is_ok()) {
-                if needs_separator {
-                    writeln!(handle, "----- {} -----", source.display())?;
-                }
-                handle.write_all(replaced.as_ref().unwrap())?;
-            }
-        } else {
-            for (source, replaced) in replaced.iter().filter(|(_, r)| r.is_ok()) {
-                let path = match source {
-                    Source::File(path) => path,
-                    Source::Stdin => {
-                        unreachable!("stdin should only go previous branch")
-                    }
-                };
-
-                if let Err(e) = write_with_temp(path, replaced.as_ref().unwrap()) {
-                    errors.push((source, e));
-                }
-            }
-        }
-
-        for (source, error) in replaced.iter().filter(|(_, r)| r.is_err()) {
-            eprintln!("error: {}: {:?}", source.display(), error);
-        }
-        for (source, error) in errors {
-            eprintln!("error: {}: {:?}", source.display(), error);
-        }
-
-        Ok(())
-    }
-}
-
-fn make_mmap(path: &PathBuf) -> Result<Mmap> {
+pub(crate) fn make_mmap(path: &PathBuf) -> Result<Mmap> {
     Ok(unsafe { Mmap::map(&File::open(path)?)? })
 }
 
-fn make_mmap_stdin() -> Result<Mmap> {
+pub(crate) fn make_mmap_stdin() -> Result<Mmap> {
     let mut handle = stdin().lock();
     let mut buf = Vec::new();
     handle.read_to_end(&mut buf)?;
@@ -113,29 +38,4 @@ fn make_mmap_stdin() -> Result<Mmap> {
     mmap.copy_from_slice(&buf);
     let mmap = mmap.make_read_only()?;
     Ok(mmap)
-}
-
-fn write_with_temp(path: &PathBuf, data: &[u8]) -> Result<()> {
-    let path = fs::canonicalize(path)?;
-
-    let temp = tempfile::NamedTempFile::new_in(
-        path.parent()
-            .ok_or_else(|| Error::InvalidPath(path.to_path_buf()))?,
-    )?;
-
-    let file = temp.as_file();
-    file.set_len(data.len() as u64)?;
-    if let Ok(metadata) = fs::metadata(&path) {
-        file.set_permissions(metadata.permissions()).ok();
-    }
-
-    if !data.is_empty() {
-        let mut mmap_temp = unsafe { MmapMut::map_mut(file)? };
-        mmap_temp.deref_mut().write_all(data)?;
-        mmap_temp.flush_async()?;
-    }
-
-    temp.persist(&path)?;
-
-    Ok(())
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,5 +1,9 @@
-use std::{path::PathBuf, fs::File, io::{stdin, Read}};
 use memmap2::{Mmap, MmapOptions};
+use std::{
+    fs::File,
+    io::{stdin, Read},
+    path::PathBuf,
+};
 
 use crate::error::Result;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     for source in sources.iter() {
         let maybe_mmap = match source {
             Source::File(path) => if path.exists() {
-                make_mmap(&path)
+                unsafe { make_mmap(&path) }
             } else {
                 Err(Error::InvalidPath(path.clone()))
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,14 +24,14 @@ fn main() {
 fn try_main() -> Result<()> {
     let options = cli::Options::parse();
 
-    let source = if !options.files.is_empty() {
-        Source::Files(options.files)
+    let sources = if !options.files.is_empty() {
+        Source::from_paths(options.files)
     } else {
-        Source::Stdin
+        Source::from_stdin()
     };
 
     App::new(
-        source,
+        sources,
         Replacer::new(
             options.find,
             options.replace_with,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,14 @@ pub(crate) use self::input::Source;
 use self::input::{make_mmap, make_mmap_stdin};
 use self::replacer::Replacer;
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = try_main() {
+        eprintln!("error: {e}");
+        process::exit(1);
+    }
+}
+
+fn try_main() -> Result<()> {
     let options = cli::Options::parse();
 
     let replacer = Replacer::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ pub(crate) mod utils;
 use std::process;
 
 pub(crate) use self::input::{App, Source};
-use ansi_term::{Color, Style};
 pub(crate) use error::{Error, Result};
 use replacer::Replacer;
 
@@ -16,7 +15,7 @@ use clap::Parser;
 
 fn main() {
     if let Err(e) = try_main() {
-        eprintln!("{}: {}", Style::from(Color::Red).bold().paint("error"), e);
+        eprintln!("{}: {}", "error", e);
         process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
         mmaps
             .par_iter()
             .map(|maybe_mmap| {
-                (maybe_mmap.as_ref().map(|mmap| replacer.replace(&mmap)))
+                maybe_mmap.as_ref().map(|mmap| replacer.replace(&mmap))
             })
             .collect()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,25 +3,32 @@ mod error;
 mod input;
 
 pub(crate) mod replacer;
-pub(crate) mod utils;
 
-use std::process;
-
-pub(crate) use self::input::{App, Source};
-pub(crate) use error::{Error, Result};
-use replacer::Replacer;
-
+use std::{
+    fs,
+    process,
+    path::PathBuf,
+    io::{stdout, Write},
+    ops::DerefMut,
+};
+use memmap2::{Mmap, MmapMut};
 use clap::Parser;
 
-fn main() {
-    if let Err(e) = try_main() {
-        eprintln!("{}: {}", "error", e);
-        process::exit(1);
-    }
-}
+pub(crate) use self::input::Source;
+pub(crate) use self::error::{Error, Result};
+use self::replacer::Replacer;
+use self::input::{make_mmap, make_mmap_stdin};
 
-fn try_main() -> Result<()> {
+fn main() -> Result<()> {
     let options = cli::Options::parse();
+
+    let replacer = Replacer::new(
+        options.find,
+        options.replace_with,
+        options.literal_mode,
+        options.flags,
+        options.replacements,
+    )?;
 
     let sources = if !options.files.is_empty() {
         Source::from_paths(options.files)
@@ -29,16 +36,89 @@ fn try_main() -> Result<()> {
         Source::from_stdin()
     };
 
-    App::new(
-        sources,
-        Replacer::new(
-            options.find,
-            options.replace_with,
-            options.literal_mode,
-            options.flags,
-            options.replacements,
-        )?,
-    )
-    .run(options.preview)?;
+    let sources: Vec<(&Source, Result<Mmap>)> = sources
+        .iter()
+        .map(|source| (source, match source {
+            Source::File(path) => if path.exists() {
+                make_mmap(path)
+            } else {
+                Err(Error::InvalidPath(path.clone()))
+            },
+            Source::Stdin => make_mmap_stdin()
+        }))
+        .collect();
+    let needs_separator = sources.len() > 1;
+
+    let replaced: Vec<_> = {
+        use rayon::prelude::*;
+        sources
+            .par_iter()
+            .map(|(source, maybe_mmap)| (source, maybe_mmap.as_ref().map(|mmap| replacer.replace(mmap))))
+            .collect()
+    };
+
+    let mut errors = Vec::new();
+    let mut has_error = !errors.is_empty();
+
+    if options.preview || sources.get(0).map(|s| s.0) == Some(&Source::Stdin) {
+        let mut handle = stdout().lock();
+
+        for (source, replaced) in replaced.iter().filter(|(_, r)| r.is_ok()) {
+            if needs_separator {
+                writeln!(handle, "----- {} -----", source.display())?;
+            }
+            handle.write_all(replaced.as_ref().unwrap())?;
+        }
+    } else {
+        for (source, replaced) in replaced.iter().filter(|(_, r)| r.is_ok()) {
+            let path = match source {
+                Source::File(path) => path,
+                Source::Stdin => {
+                    unreachable!("stdin should only go previous branch")
+                }
+            };
+
+            if let Err(e) = write_with_temp(path, replaced.as_ref().unwrap()) {
+                errors.push((source, e));
+            }
+        }
+    }
+
+    for (source, error) in replaced.iter().filter(|(_, r)| r.is_err()) {
+        eprintln!("error: {}: {:?}", source.display(), error);
+        has_error = true;
+    }
+    for (source, error) in errors {
+        eprintln!("error: {}: {:?}", source.display(), error);
+    }
+
+    if has_error {
+        process::exit(1);
+    }
+    Ok(())
+}
+
+fn write_with_temp(path: &PathBuf, data: &[u8]) -> Result<()> {
+    let path = fs::canonicalize(path)?;
+
+    let temp = tempfile::NamedTempFile::new_in(
+        path.parent()
+            .ok_or_else(|| Error::InvalidPath(path.to_path_buf()))?,
+    )?;
+
+    let file = temp.as_file();
+    file.set_len(data.len() as u64)?;
+    if let Ok(metadata) = fs::metadata(&path) {
+        file.set_permissions(metadata.permissions()).ok();
+    }
+
+    if !data.is_empty() {
+        let mut mmap_temp = unsafe { MmapMut::map_mut(file)? };
+        mmap_temp.deref_mut().write_all(data)?;
+        mmap_temp.flush_async()?;
+    }
+
+    temp.persist(&path)?;
+
     Ok(())
 }

--- a/src/replacer/mod.rs
+++ b/src/replacer/mod.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{utils, Result};
+use crate::Result;
 
 use regex::bytes::Regex;
 
@@ -32,7 +32,7 @@ impl Replacer {
 
             (
                 look_for,
-                utils::unescape(&replace_with)
+                unescape::unescape(&replace_with)
                     .unwrap_or(replace_with)
                     .into_bytes(),
             )

--- a/src/replacer/mod.rs
+++ b/src/replacer/mod.rs
@@ -74,10 +74,7 @@ impl Replacer {
         })
     }
 
-    pub(crate) fn replace<'a>(
-        &'a self,
-        content: &'a [u8],
-    ) -> std::borrow::Cow<'a, [u8]> {
+    pub(crate) fn replace<'a>(&'a self, content: &'a [u8]) -> Cow<'a, [u8]> {
         let regex = &self.regex;
         let limit = self.replacements;
         let use_color = false;

--- a/src/replacer/mod.rs
+++ b/src/replacer/mod.rs
@@ -103,7 +103,7 @@ impl Replacer {
         regex: &regex::bytes::Regex,
         limit: usize,
         haystack: &'haystack [u8],
-        use_color: bool,
+        _use_color: bool,
         mut rep: R,
     ) -> Cow<'haystack, [u8]> {
         let mut it = regex.captures_iter(haystack).enumerate().peekable();
@@ -116,17 +116,7 @@ impl Replacer {
             // unwrap on 0 is OK because captures only reports matches
             let m = cap.get(0).unwrap();
             new.extend_from_slice(&haystack[last_match..m.start()]);
-            if use_color {
-                new.extend_from_slice(
-                    ansi_term::Color::Blue.prefix().to_string().as_bytes(),
-                );
-            }
             rep.replace_append(&cap, &mut new);
-            if use_color {
-                new.extend_from_slice(
-                    ansi_term::Color::Blue.suffix().to_string().as_bytes(),
-                );
-            }
             last_match = m.end();
             if limit > 0 && i >= limit - 1 {
                 break;

--- a/src/replacer/validate.rs
+++ b/src/replacer/validate.rs
@@ -54,7 +54,11 @@ impl fmt::Display for InvalidReplaceCapture {
         for (byte_index, c) in original_replace.char_indices() {
             let (prefix, suffix, text) = match SpecialChar::new(c) {
                 Some(c) => {
-                    (Some("" /* special prefix */), Some("" /* special suffix */), c.render())
+                    (
+                        Some("" /* special prefix */),
+                        Some("" /* special suffix */),
+                        c.render(),
+                    )
                 }
                 None => {
                     let (prefix, suffix) = if byte_index == invalid_ident.start
@@ -93,10 +97,7 @@ impl fmt::Display for InvalidReplaceCapture {
         // This relies on all non-curly-braced capture chars being 1 byte
         let arrows_span = arrows_start.end_offset(invalid_ident.len());
         let mut arrows = " ".repeat(arrows_span.start);
-        arrows.push_str(&format!(
-            "{}",
-            "^".repeat(arrows_span.len())
-        ));
+        arrows.push_str(&format!("{}", "^".repeat(arrows_span.len())));
 
         let ident = invalid_ident.slice(original_replace);
         let (number, the_rest) = ident.split_at(*num_leading_digits);
@@ -107,8 +108,7 @@ impl fmt::Display for InvalidReplaceCapture {
         );
         let hint_message = format!(
             "{}: Use curly braces to disambiguate it `{}`.",
-            "hint",
-            disambiguous
+            "hint", disambiguous
         );
 
         writeln!(f, "{}", error_message)?;

--- a/src/replacer/validate.rs
+++ b/src/replacer/validate.rs
@@ -1,7 +1,5 @@
 use std::{error::Error, fmt, str::CharIndices};
 
-use ansi_term::{Color, Style};
-
 #[derive(Debug)]
 pub struct InvalidReplaceCapture {
     original_replace: String,
@@ -53,21 +51,19 @@ impl fmt::Display for InvalidReplaceCapture {
         // Build up the error to show the user
         let mut formatted = String::new();
         let mut arrows_start = Span::start_at(0);
-        let special = Style::new().bold();
-        let error = Style::from(Color::Red).bold();
         for (byte_index, c) in original_replace.char_indices() {
             let (prefix, suffix, text) = match SpecialChar::new(c) {
                 Some(c) => {
-                    (Some(special.prefix()), Some(special.suffix()), c.render())
+                    (Some("" /* special prefix */), Some("" /* special suffix */), c.render())
                 }
                 None => {
                     let (prefix, suffix) = if byte_index == invalid_ident.start
                     {
-                        (Some(error.prefix()), None)
+                        (Some("" /* error prefix */), None)
                     } else if byte_index
                         == invalid_ident.end.checked_sub(1).unwrap()
                     {
-                        (None, Some(error.suffix()))
+                        (None, Some("" /* error suffix */))
                     } else {
                         (None, None)
                     };
@@ -99,7 +95,7 @@ impl fmt::Display for InvalidReplaceCapture {
         let mut arrows = " ".repeat(arrows_span.start);
         arrows.push_str(&format!(
             "{}",
-            Style::new().bold().paint("^".repeat(arrows_span.len()))
+            "^".repeat(arrows_span.len())
         ));
 
         let ident = invalid_ident.slice(original_replace);
@@ -107,12 +103,12 @@ impl fmt::Display for InvalidReplaceCapture {
         let disambiguous = format!("${{{number}}}{the_rest}");
         let error_message = format!(
             "The numbered capture group `{}` in the replacement text is ambiguous.",
-            Style::new().bold().paint(format!("${}", number).to_string())
+            format!("${}", number).to_string()
         );
         let hint_message = format!(
             "{}: Use curly braces to disambiguate it `{}`.",
-            Style::from(Color::Blue).bold().paint("hint"),
-            Style::new().bold().paint(disambiguous)
+            "hint",
+            disambiguous
         );
 
         writeln!(f, "{}", error_message)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,0 @@
-pub(crate) fn unescape(s: &str) -> Option<String> {
-    unescape::unescape(s)
-}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -137,7 +137,7 @@ mod cli {
     fn ambiguous_replace_basic() {
         let plain_stderr = bad_replace_helper_plain("before $1bad after");
         insta::assert_snapshot!(plain_stderr, @r###"
-        Error: The numbered capture group `$1` in the replacement text is ambiguous.
+        error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}bad`.
         before $1bad after
                 ^^^^
@@ -148,7 +148,7 @@ mod cli {
     fn ambiguous_replace_variable_width() {
         let plain_stderr = bad_replace_helper_plain("\r\n\t$1bad\r");
         insta::assert_snapshot!(plain_stderr, @r###"
-        Error: The numbered capture group `$1` in the replacement text is ambiguous.
+        error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}bad`.
         ␍␊␉$1bad␍
             ^^^^
@@ -159,7 +159,7 @@ mod cli {
     fn ambiguous_replace_multibyte_char() {
         let plain_stderr = bad_replace_helper_plain("😈$1bad😇");
         insta::assert_snapshot!(plain_stderr, @r###"
-        Error: The numbered capture group `$1` in the replacement text is ambiguous.
+        error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}bad`.
         😈$1bad😇
           ^^^^
@@ -171,7 +171,7 @@ mod cli {
         let plain_stderr =
             bad_replace_helper_plain("$1Call $2($5, GetFM20ReturnKey(), $6)");
         insta::assert_snapshot!(plain_stderr, @r###"
-        Error: The numbered capture group `$1` in the replacement text is ambiguous.
+        error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}Call`.
         $1Call $2($5, GetFM20ReturnKey(), $6)
          ^^^^^

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,14 +13,12 @@ mod cli {
         assert_eq!(content, std::fs::read_to_string(path).unwrap());
     }
 
+    #[cfg(target_family = "unix")]
     fn create_soft_link<P: AsRef<std::path::Path>>(
         src: &P,
         dst: &P,
     ) -> Result<()> {
-        #[cfg(target_family = "unix")]
         std::os::unix::fs::symlink(src, dst)?;
-        #[cfg(target_family = "windows")]
-        std::os::windows::fs::symlink_file(src, dst)?;
 
         Ok(())
     }
@@ -53,6 +51,7 @@ mod cli {
         Ok(())
     }
 
+    #[cfg(target_family = "unix")]
     #[test]
     fn in_place_following_symlink() -> Result<()> {
         let dir = tempfile::tempdir()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -174,7 +174,8 @@ mod cli {
 
     // NOTE: styled terminal output is platform dependent, so convert to a
     // common format, in this case HTML, to check
-    //#[test]
+    #[ignore = "TODO: wait for proper colorization"]
+    #[test]
     fn ambiguous_replace_ensure_styling() {
         let styled_stderr = bad_replace_helper_styled("\t$1bad after");
         let html_stderr =

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -347,7 +347,7 @@ mod cli {
 
             let test_dir =
                 tempfile::Builder::new().prefix("sd-test-").tempdir()?;
-            let test_home = test_dir.path();
+            let test_home = test_dir.path().canonicalize()?;
 
             let writable_dir = test_home.join("writable");
             fs::create_dir(&writable_dir)?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,7 +3,7 @@
 mod cli {
     use anyhow::Result;
     use assert_cmd::Command;
-    use std::io::prelude::*;
+    use std::{fs, io::prelude::*, path::Path};
 
     fn sd() -> Command {
         Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Error invoking sd")
@@ -245,5 +245,159 @@ mod cli {
             .assert()
             .success()
             .stdout("bar\nfoo\nfoo");
+    }
+
+    const UNTOUCHED_CONTENTS: &str = "untouched";
+
+    fn assert_fails_correctly(
+        command: &mut Command,
+        valid: &Path,
+        test_home: &Path,
+        snap_name: &str,
+    ) {
+        let failed_command = command.assert().failure().code(1);
+
+        assert_eq!(fs::read_to_string(&valid).unwrap(), UNTOUCHED_CONTENTS);
+
+        let stderr_orig =
+            std::str::from_utf8(&failed_command.get_output().stderr).unwrap();
+        // Normalize unstable path bits
+        let stderr_norm = stderr_orig
+            .replace(test_home.to_str().unwrap(), "<test_home>")
+            .replace('\\', "/");
+        insta::assert_snapshot!(snap_name, stderr_norm);
+    }
+
+    #[test]
+    fn correctly_fails_on_missing_file() -> Result<()> {
+        let test_dir = tempfile::Builder::new().prefix("sd-test-").tempdir()?;
+        let test_home = test_dir.path();
+
+        let valid = test_home.join("valid");
+        fs::write(&valid, UNTOUCHED_CONTENTS)?;
+        let missing = test_home.join("missing");
+
+        assert_fails_correctly(
+            sd().args([".*", ""]).arg(&valid).arg(&missing),
+            &valid,
+            test_home,
+            "correctly_fails_on_missing_file",
+        );
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(target_family = "unix"), ignore = "only runs on unix")]
+    #[test]
+    fn correctly_fails_on_unreadable_file() -> Result<()> {
+        #[cfg(not(target_family = "unix"))]
+        {
+            unreachable!("This test should be ignored");
+        }
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+
+            let test_dir =
+                tempfile::Builder::new().prefix("sd-test-").tempdir()?;
+            let test_home = test_dir.path();
+
+            let valid = test_home.join("valid");
+            fs::write(&valid, UNTOUCHED_CONTENTS)?;
+            let write_only = {
+                let path = test_home.join("write_only");
+                let mut write_only_file = std::fs::OpenOptions::new()
+                    .mode(0o333)
+                    .create(true)
+                    .write(true)
+                    .open(&path)?;
+                write!(write_only_file, "unreadable")?;
+                path
+            };
+
+            assert_fails_correctly(
+                sd().args([".*", ""]).arg(&valid).arg(&write_only),
+                &valid,
+                test_home,
+                "correctly_fails_on_unreadable_file",
+            );
+
+            Ok(())
+        }
+    }
+
+    // Failing to create a temporary file in the same directory as the input is
+    // one of the failure cases that is past the "point of no return" (after we
+    // already start making replacements). This means that any files that could
+    // be modified are, and we report any failure cases
+    #[cfg_attr(not(target_family = "unix"), ignore = "only runs on unix")]
+    #[test]
+    fn reports_errors_on_atomic_file_swap_creation_failure() -> Result<()> {
+        #[cfg(not(target_family = "unix"))]
+        {
+            unreachable!("This test should be ignored");
+        }
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            const FIND_REPLACE: [&str; 2] = ["able", "ed"];
+            const ORIG_TEXT: &str = "modifiable";
+            const MODIFIED_TEXT: &str = "modified";
+
+            let test_dir =
+                tempfile::Builder::new().prefix("sd-test-").tempdir()?;
+            let test_home = test_dir.path();
+
+            let writable_dir = test_home.join("writable");
+            fs::create_dir(&writable_dir)?;
+            let writable_dir_file = writable_dir.join("foo");
+            fs::write(&writable_dir_file, ORIG_TEXT)?;
+
+            let unwritable_dir = test_home.join("unwritable");
+            fs::create_dir(&unwritable_dir)?;
+            let unwritable_dir_file1 = unwritable_dir.join("bar");
+            fs::write(&unwritable_dir_file1, ORIG_TEXT)?;
+            let unwritable_dir_file2 = unwritable_dir.join("baz");
+            fs::write(&unwritable_dir_file2, ORIG_TEXT)?;
+            let mut perms = fs::metadata(&unwritable_dir)?.permissions();
+            perms.set_mode(0o555);
+            fs::set_permissions(&unwritable_dir, perms)?;
+
+            let failed_command = sd()
+                .args(FIND_REPLACE)
+                .arg(&writable_dir_file)
+                .arg(&unwritable_dir_file1)
+                .arg(&unwritable_dir_file2)
+                .assert()
+                .failure()
+                .code(1);
+
+            // Confirm that we modified the one file that we were able to
+            assert_eq!(fs::read_to_string(&writable_dir_file)?, MODIFIED_TEXT);
+            assert_eq!(fs::read_to_string(&unwritable_dir_file1)?, ORIG_TEXT);
+            assert_eq!(fs::read_to_string(&unwritable_dir_file2)?, ORIG_TEXT);
+
+            let stderr_orig =
+                std::str::from_utf8(&failed_command.get_output().stderr)
+                    .unwrap();
+            // Normalize unstable path bits
+            let stderr_partial_norm = stderr_orig
+                .replace(test_home.to_str().unwrap(), "<test_home>")
+                .replace('\\', "/");
+            let tmp_file_rep = regex::Regex::new(r"\.tmp\w+")?;
+            let stderr_norm =
+                tmp_file_rep.replace_all(&stderr_partial_norm, "<tmp_file>");
+            insta::assert_snapshot!(stderr_norm);
+
+            // Make the unwritable dir writable again, so it can be cleaned up
+            // when dropping the temp dir
+            let mut perms = fs::metadata(&unwritable_dir)?.permissions();
+            perms.set_mode(0o777);
+            fs::set_permissions(&unwritable_dir, perms)?;
+            test_dir.close()?;
+
+            Ok(())
+        }
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -109,7 +109,7 @@ mod cli {
 
     fn bad_replace_helper_plain(replace: &str) -> String {
         let stderr = bad_replace_helper_styled(replace);
-		stderr
+        stderr
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -81,11 +81,7 @@ mod cli {
         sd().args(["-p", "abc\\d+", "", file.path().to_str().unwrap()])
             .assert()
             .success()
-            .stdout(format!(
-                "{}{}def\n",
-                ansi_term::Color::Blue.prefix(),
-                ansi_term::Color::Blue.suffix()
-            ));
+            .stdout("def");
 
         assert_file(file.path(), "abc123def");
 
@@ -113,13 +109,7 @@ mod cli {
 
     fn bad_replace_helper_plain(replace: &str) -> String {
         let stderr = bad_replace_helper_styled(replace);
-
-        // TODO: no easy way to toggle off styling yet. Add a `--color <when>`
-        // flag, and respect things like `$NO_COLOR`. `ansi_term` is
-        // unmaintained, so we should migrate off of it anyways
-        console::AnsiCodeIterator::new(&stderr)
-            .filter_map(|(s, is_ansi)| (!is_ansi).then_some(s))
-            .collect()
+		stderr
     }
 
     #[test]
@@ -182,7 +172,7 @@ mod cli {
 
     // NOTE: styled terminal output is platform dependent, so convert to a
     // common format, in this case HTML, to check
-    #[test]
+    //#[test]
     fn ambiguous_replace_ensure_styling() {
         let styled_stderr = bad_replace_helper_styled("\t$1bad after");
         let html_stderr =
@@ -225,10 +215,7 @@ mod cli {
         ])
         .assert()
         .success()
-        .stdout(format!(
-            "{}\nfoo\nfoo\n",
-            ansi_term::Color::Blue.paint("bar")
-        ));
+        .stdout("bar\nfoo\nfoo");
 
         Ok(())
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -128,7 +128,7 @@ mod cli {
     fn ambiguous_replace_basic() {
         let plain_stderr = bad_replace_helper_plain("before $1bad after");
         insta::assert_snapshot!(plain_stderr, @r###"
-        error: The numbered capture group `$1` in the replacement text is ambiguous.
+        Error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}bad`.
         before $1bad after
                 ^^^^
@@ -139,7 +139,7 @@ mod cli {
     fn ambiguous_replace_variable_width() {
         let plain_stderr = bad_replace_helper_plain("\r\n\t$1bad\r");
         insta::assert_snapshot!(plain_stderr, @r###"
-        error: The numbered capture group `$1` in the replacement text is ambiguous.
+        Error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}bad`.
         ␍␊␉$1bad␍
             ^^^^
@@ -150,7 +150,7 @@ mod cli {
     fn ambiguous_replace_multibyte_char() {
         let plain_stderr = bad_replace_helper_plain("😈$1bad😇");
         insta::assert_snapshot!(plain_stderr, @r###"
-        error: The numbered capture group `$1` in the replacement text is ambiguous.
+        Error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}bad`.
         😈$1bad😇
           ^^^^
@@ -162,7 +162,7 @@ mod cli {
         let plain_stderr =
             bad_replace_helper_plain("$1Call $2($5, GetFM20ReturnKey(), $6)");
         insta::assert_snapshot!(plain_stderr, @r###"
-        error: The numbered capture group `$1` in the replacement text is ambiguous.
+        Error: The numbered capture group `$1` in the replacement text is ambiguous.
         hint: Use curly braces to disambiguate it `${1}Call`.
         $1Call $2($5, GetFM20ReturnKey(), $6)
          ^^^^^

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -13,11 +13,14 @@ mod cli {
         assert_eq!(content, std::fs::read_to_string(path).unwrap());
     }
 
-    #[cfg(target_family = "unix")]
+    // This should really be cfg_attr(target_family = "windows"), but wasi impl
+    // is nightly for now, and other impls are not part of std
+    #[cfg_attr(not(target_family = "unix"), ignore = "Windows symlinks are privileged")]
     fn create_soft_link<P: AsRef<std::path::Path>>(
         src: &P,
         dst: &P,
     ) -> Result<()> {
+        #[cfg(target_family = "unix")]
         std::os::unix::fs::symlink(src, dst)?;
 
         Ok(())
@@ -51,7 +54,7 @@ mod cli {
         Ok(())
     }
 
-    #[cfg(target_family = "unix")]
+    #[cfg_attr(target_family = "windows", ignore = "Windows symlinks are privileged")]
     #[test]
     fn in_place_following_symlink() -> Result<()> {
         let dir = tempfile::tempdir()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -15,7 +15,10 @@ mod cli {
 
     // This should really be cfg_attr(target_family = "windows"), but wasi impl
     // is nightly for now, and other impls are not part of std
-    #[cfg_attr(not(target_family = "unix"), ignore = "Windows symlinks are privileged")]
+    #[cfg_attr(
+        not(target_family = "unix"),
+        ignore = "Windows symlinks are privileged"
+    )]
     fn create_soft_link<P: AsRef<std::path::Path>>(
         src: &P,
         dst: &P,
@@ -54,7 +57,10 @@ mod cli {
         Ok(())
     }
 
-    #[cfg_attr(target_family = "windows", ignore = "Windows symlinks are privileged")]
+    #[cfg_attr(
+        target_family = "windows",
+        ignore = "Windows symlinks are privileged"
+    )]
     #[test]
     fn in_place_following_symlink() -> Result<()> {
         let dir = tempfile::tempdir()?;

--- a/tests/snapshots/cli__cli__correctly_fails_on_missing_file.snap
+++ b/tests/snapshots/cli__cli__correctly_fails_on_missing_file.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: stderr_norm
+---
+error: invalid path: <test_home>/missing
+

--- a/tests/snapshots/cli__cli__correctly_fails_on_unreadable_file.snap
+++ b/tests/snapshots/cli__cli__correctly_fails_on_unreadable_file.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+expression: stderr_norm
+---
+error: Permission denied (os error 13)
+

--- a/tests/snapshots/cli__cli__reports_errors_on_atomic_file_swap_creation_failure.snap
+++ b/tests/snapshots/cli__cli__reports_errors_on_atomic_file_swap_creation_failure.snap
@@ -1,0 +1,9 @@
+---
+source: tests/cli.rs
+expression: stderr_norm
+---
+error: Failed processing some inputs
+    <test_home>/unwritable/bar: Permission denied (os error 13) at path "<test_home>/unwritable/<tmp_file>"
+    <test_home>/unwritable/baz: Permission denied (os error 13) at path "<test_home>/unwritable/<tmp_file>"
+
+


### PR DESCRIPTION
This is the refactor I talked about in https://github.com/chmln/sd/pull/238. Sources are unified into a `Vec` of `Mmap`s, abstracting away the need for `replace_{file,preview}`.