### PR TITLE
Make modified text blue instead of green

### DIFF
--- a/src/replacer/mod.rs
+++ b/src/replacer/mod.rs
@@ -131,13 +131,13 @@ impl Replacer {
             new.extend_from_slice(&haystack[last_match..m.start()]);
             if use_color {
                 new.extend_from_slice(
-                    ansi_term::Color::Green.prefix().to_string().as_bytes(),
+                    ansi_term::Color::Blue.prefix().to_string().as_bytes(),
                 );
             }
             rep.replace_append(&cap, &mut new);
             if use_color {
                 new.extend_from_slice(
-                    ansi_term::Color::Green.suffix().to_string().as_bytes(),
+                    ansi_term::Color::Blue.suffix().to_string().as_bytes(),
                 );
             }
             last_match = m.end();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -83,8 +83,8 @@ mod cli {
             .success()
             .stdout(format!(
                 "{}{}def\n",
-                ansi_term::Color::Green.prefix(),
-                ansi_term::Color::Green.suffix()
+                ansi_term::Color::Blue.prefix(),
+                ansi_term::Color::Blue.suffix()
             ));
 
         assert_file(file.path(), "abc123def");
@@ -227,7 +227,7 @@ mod cli {
         .success()
         .stdout(format!(
             "{}\nfoo\nfoo\n",
-            ansi_term::Color::Green.paint("bar")
+            ansi_term::Color::Blue.paint("bar")
         ));
 
         Ok(())


### PR DESCRIPTION
The motivation here is that using green for the modified text section seems a bit confusing. As developers we're trained to recognize green as additions which implies the use of red for deletions

In `sd` though the only portion that is retained is just the additions, so it's best to pick a different color for it. This also avoids confusion when adding any diffing functionality to `sd` in the future