### PR TITLE
Remove outdated release checklist step

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,6 @@
 1. [ ] Create a new _"Release v{VERSION}"_ issue with this checklist
     - `$ cat RELEASE.md | sd '\{VERSION\}' '{NEW_VERSION}' | xclip -sel clip`
     - Create the issue in GitHub
-1. [ ] Ensure that all entries in the man page are up to date
-    - Manually verify with the entries in `xtask/src/gen.rs`
 1. [ ] Regenerate static assets
     - `$ cargo xtask gen`
 1. [ ] Update `rust-version` in `Cargo.toml`


### PR DESCRIPTION
Previously the entries in the man page were manually copied in with slightly tweaked formatting. This was changed to automatically extract all the entries using `clap_mangen` though which makes the step to make sure that manpage entries are all up to date, no longer a requirement.