### PR TITLE
Update `sd` version in lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sd"
-version = "0.7.6"
+version = "1.0.0-beta.0"
 dependencies = [
  "ansi-to-html",
  "ansi_term",
@@ -961,7 +961,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "xtask"
-version = "0.7.6"
+version = "1.0.0-beta.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 1. [ ] Update `rust-version` in `Cargo.toml`
     - `$ cargo msrv --min 1.60 -- cargo check`
 1. [ ] Bump `version` in `Cargo.toml`
+1. [ ] Run `cargo check` to propogate the change to `Cargo.lock`
 1. [ ] Update the `CHANGELOG.md`
 1. [ ] Merge changes through a PR to make sure that CI passes
 1. [ ] Publish on [crates.io](crates.io)


### PR DESCRIPTION
Looks like `--locked` in the publish action is failing because the `sd` version in the lockfile is out of date. The addition to the release checklist should ensure this doesn't happen in the future