### PR TITLE
Fix string literal argument in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Install through
 1. **String-literal mode**. By default, expressions are treated as regex. Use `-F` or `--fixed-strings` to disable regex.
 
    ```sh
-   > echo 'lots((([]))) of special chars' | sd -s '((([])))' ''
+   > echo 'lots((([]))) of special chars' | sd -F '((([])))' ''
    lots of special chars
    ```
 


### PR DESCRIPTION
The example for string literal mode mentions the new official argument (`-F` or `--fixed-strings`), but still uses the old, now undocumented, `-s` argument. This is confusing for anyone who doesn't know the old syntax.