### PR TITLE
docs: fix capture group example in man page

### DIFF
--- a/xtask/src/gen.rs
+++ b/xtask/src/gen.rs
@@ -70,7 +70,7 @@ fn gen_man(base_dir: &Path) {
         (
             "Indexed capture groups",
             r"echo 'cargo +nightly watch' | sd '(\w+)\s+\+(\w+)\s+(\w+)' 'cmd: $1, channel: $2, subcmd: $3'",
-            "123 dollars and 45 cents",
+            "cmd: cargo, channel: nightly, subcmd: watch",
         ),
         (
             "Find & replace in file",


### PR DESCRIPTION
Hi, thanks for making this tool. I believe this fixes an outdated man page example. Thank you.