### PR TITLE
deps: bump libc from 0.2.149 to 0.2.155

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,9 +345,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"


### PR DESCRIPTION
Hi, I had to update libc to 0.2.155 to support LoongArch64, because sd compilation based on musl LoongArch64 failed.
https://github.com/rust-lang/libc/pull/3606

Release notes :https://github.com/rust-lang/libc/releases

Thanks.


