### PR TITLE
fix(manpage): add missing single quotes in example

### DIFF
--- a/gen/sd.1
+++ b/gen/sd.1
@@ -70,7 +70,7 @@ The program panicked.
 .SH EXAMPLES
 .TP
 String\-literal mode
-\fB$ echo \*(Aqlots((([]))) of special chars\*(Aq | sd \-F \*(Aq((([])))\*(Aq\fR
+\fB$ echo \*(Aqlots((([]))) of special chars\*(Aq | sd \-F \*(Aq((([])))\*(Aq \*(Aq\*(Aq\fR
 .br
 lots of special chars
 .TP

--- a/xtask/src/gen.rs
+++ b/xtask/src/gen.rs
@@ -59,7 +59,7 @@ fn gen_man(base_dir: &Path) {
         // (description, command, result), result can be empty
         (
             "String-literal mode",
-            "echo 'lots((([]))) of special chars' | sd -F '((([])))'",
+            "echo 'lots((([]))) of special chars' | sd -F '((([])))' ''",
             "lots of special chars",
         ),
         (


### PR DESCRIPTION
* Update man page example to include the empty replacement string (`''`)

* Update corresponding example in `cargo-xtask` generator to stay consistent