### PR TITLE
fix: bump version to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sd"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "insta",
  "proptest",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "sd-cli"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "ansi-to-html",
  "anyhow",
@@ -897,7 +897,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "xtask"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = {version =  "4.4.6", features = ["derive", "wrap_help"]}
 
 [workspace.package]
 edition = "2024"
-version = "1.0.0"
+version = "1.1.1"
 authors = ["Gregory <gregory.mkv@gmail.com>", "Orión <oriongonza42@pm.me>"]
 description = "An intuitive find & replace CLI"
 readme = "../README.md"

--- a/gen/sd.1
+++ b/gen/sd.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH sd 1  "sd 1.0.0" 
+.TH sd 1  "sd 1.1.1" 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH NAME


### PR DESCRIPTION
## Summary
- `sd --version` was incorrectly reporting `1.0.0` instead of `1.1.1`
- Updates version in `Cargo.toml` (workspace), `Cargo.lock`, and the man page (`gen/sd.1`)

## Test plan
- [x] `cargo run --bin sd -- --version` reports `sd 1.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)