### PR TITLE
ci: use native runner for Windows ARM64 releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,23 @@ jobs:
       with:
         fetch-depth: 1
 
+    - name: Install Windows ARM64 GNU-family linker
+      if: ${{ matrix.target == 'aarch64-pc-windows-gnullvm' }}
+      id: msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        update: true
+        install: mingw-w64-clang-aarch64-clang
+    - name: Expose Windows ARM64 GNU-family linker
+      if: ${{ matrix.target == 'aarch64-pc-windows-gnullvm' }}
+      shell: pwsh
+      env:
+        MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
+      run: |
+        echo "$env:MSYS2_LOCATION\\clangarm64\\bin" >> $env:GITHUB_PATH
+        echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER=$env:MSYS2_LOCATION\\clangarm64\\bin\\clang.exe" >> $env:GITHUB_ENV
+
     - name: Set the version
       shell: bash
       if: env.SD_VERSION == ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,10 @@ jobs:
             target: aarch64-pc-windows-msvc
             use-cross: false
 
+          - os: windows-11-arm
+            target: aarch64-pc-windows-gnullvm
+            use-cross: false
+
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
@@ -100,7 +104,7 @@ jobs:
         $CARGO --version
         $CARGO build --release --locked --target ${{ matrix.target }}
         # Handle windows being an oddity
-        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+        if [[ "${{ matrix.target }}" == *-windows-* ]]; then
           echo "BIN_NAME=sd.exe" >> $GITHUB_ENV
         else
           echo "BIN_NAME=sd" >> $GITHUB_ENV
@@ -113,7 +117,7 @@ jobs:
         mkdir -p "$staging"
 
         cp -r {README.md,LICENSE,CHANGELOG.md,gen/*} "$staging"
-        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+        if [[ "${{ matrix.target }}" == *-windows-* ]]; then
           cp "target/${{ matrix.target }}/release/sd.exe" "$staging/"
           7z a "$staging.zip" "$staging"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             use-cross: false
 
-          - os: windows-latest
+          - os: windows-11-arm
             target: aarch64-pc-windows-msvc
             use-cross: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             use-cross: false
 
-          - os: windows-latest
+          - os: windows-11-arm
             target: aarch64-pc-windows-msvc
+            use-cross: false
+
+          - os: windows-11-arm
+            target: aarch64-pc-windows-gnullvm
             use-cross: false
 
           - os: macos-latest
@@ -93,7 +97,7 @@ jobs:
           # For legal reasons, cross doesn't support Apple Silicon. See this:
           # https://github.com/cross-rs/cross-toolchains#darwin-targets
           # It builds and runs fine, but there's no easy way to test it in CI
-        if [ "${{ matrix.use-cross }}" = "true" ] || [ "${{ matrix.target }}" = "aarch64-apple-darwin" ] || [ "${{ matrix.target }}" = "aarch64-pc-windows-msvc" ]; then
+        if [ "${{ matrix.use-cross }}" = "true" ] || [ "${{ matrix.target }}" = "aarch64-apple-darwin" ] || [[ "${{ matrix.target }}" == aarch64-pc-windows-* ]]; then
           $CARGO build --target ${{ matrix.target }}
         else
           $CARGO test --target ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,23 @@ jobs:
       with:
         fetch-depth: 1
 
+    - name: Install Windows ARM64 GNU-family linker
+      if: ${{ matrix.target == 'aarch64-pc-windows-gnullvm' }}
+      id: msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: CLANGARM64
+        update: true
+        install: mingw-w64-clang-aarch64-clang
+    - name: Expose Windows ARM64 GNU-family linker
+      if: ${{ matrix.target == 'aarch64-pc-windows-gnullvm' }}
+      shell: pwsh
+      env:
+        MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
+      run: |
+        echo "$env:MSYS2_LOCATION\\clangarm64\\bin" >> $env:GITHUB_PATH
+        echo "CARGO_TARGET_AARCH64_PC_WINDOWS_GNULLVM_LINKER=$env:MSYS2_LOCATION\\clangarm64\\bin\\clang.exe" >> $env:GITHUB_ENV
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:


### PR DESCRIPTION
## Summary

- Run the existing aarch64-pc-windows-msvc release and test jobs on GitHub native windows-11-arm runners.
- Add the Windows ARM64 GNU-family Rust target, aarch64-pc-windows-gnullvm. Rust does not provide a literal aarch64-pc-windows-gnu target.
- Package every Windows target by target triple, so ARM64 binaries are archived as ZIP files with sd.exe.

## Toolchain

The GNU-family target installs the MSYS2 CLANGARM64 toolchain and uses the setup action output for Cargo linker configuration. This avoids a runner-specific hard-coded path.

## Validation

- Existing MSVC native-runner smoke: [successful build and archive](https://github.com/meop/sd/actions/runs/33243840862).
- GNU-family native-runner smoke: [successful build, ZIP package, and artifact upload](https://github.com/meop/sd/actions/runs/33565744462).

The fork-only validation workflow is not included in this PR.